### PR TITLE
Fix elevation cleanup to match queries sent to Solr

### DIFF
--- a/packages/types/solrProContentType.cfc
+++ b/packages/types/solrProContentType.cfc
@@ -1007,7 +1007,7 @@
 		
 		<!--- add a typename filter --->
 		<cfif listLen(arguments.lContentTypes)>
-			<cfset q = q & " AND +(" />
+			<cfset q = q & " AND (" />
 			
 			<cfset var counter = 0 />
 			<cfloop list="#arguments.lContentTypes#" index="type">
@@ -1025,10 +1025,10 @@
 		</cfif>
 		
 		<cfif arguments.bFilterBySite>
-			<cfset q = q & " AND +(fcsp_sitename:" & application.applicationName & ")" />
+			<cfset q = q & " AND (fcsp_sitename:" & application.applicationName & ")" />
 		</cfif>
 		
-		<cfset q = q & " AND +fcsp_benablesearch:true" />
+		<cfset q = q & " AND fcsp_benablesearch:true" />
 		
 		<cfreturn q />
 		

--- a/templates/conf/schema.xml
+++ b/templates/conf/schema.xml
@@ -186,8 +186,8 @@
        	<filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         
-        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern=" AND \(fcsp_sitename:(.*)\)" replacement="" />
-        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern=" AND \(typename:(.*)\)" replacement="" />
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern=" AND \(fcsp_sitename:([^)]+)\)" replacement="" />
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern=" AND \((typename:([^)]+)( OR )?)+\)" replacement="" />
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern=" AND fcsp_benablesearch:(true|false)" replacement="" />
       </analyzer>
     </fieldType>


### PR DESCRIPTION
It looks like some of my previous tweaks to the Solr query builder broke query elevation.

This commit removes the breakage and improves the regexs used to clean up queries for elevation.
